### PR TITLE
Update OSQP Installation Process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ cpp.sublime-workspace
 .vscode/
 .cache/
 .idea/
+**/CMakeCache.txt
+CMakeFiles/**
 
 # whitelist documentation
 !docs/**

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,6 +11,3 @@
 [submodule "python/carma"]
 	path = python/carma
 	url = https://github.com/RUrlus/carma.git
-[submodule "osqp"]
-	path = osqp
-	url = https://github.com/osqp/osqp

--- a/cmake/Modules/OSQP.cmake
+++ b/cmake/Modules/OSQP.cmake
@@ -1,2 +1,13 @@
+include(FetchContent)
+message(STATUS "Fetching & installing osqp")
+FetchContent_Declare(
+    osqp
+    PREFIX ${CMAKE_BINARY_DIR}/osqp
+    GIT_REPOSITORY https://github.com/osqp/osqp.git
+    GIT_TAG 4e81a9d0
+)
+FetchContent_MakeAvailable(osqp)
+message(STATUS "Installed osqp to ${osqp_BINARY_DIR}")
+list(APPEND CMAKE_PREFIX_PATH ${osqp_BINARY_DIR})
 find_package(osqp REQUIRED)
 list(APPEND PROJECT_REQUIRED_LIBRARIES_ABSOLUTE_NAME osqp::osqp)

--- a/examples/plot_lqmpc_ctrl_output.m
+++ b/examples/plot_lqmpc_ctrl_output.m
@@ -41,4 +41,4 @@ stairs(t, j', 'LineWidth', 2, 'color', c_cost);
 ylabel({'Cost'})
 
 % Save the figure
-printfig('eg_glds_ctrl_output', 'png', gcf, [8 8]);
+printfig('eg_lqmpc_ctrl_output', 'png', gcf, [8 8]);


### PR DESCRIPTION
The original approach to using OSQP involved installing OSQP as a submodule and configuring it manually. However, this is less convenient, especially because other required packages use either `vcpkg` to install or could be recognized just with `add_subdirectory`. Instead, the new approach that is taken is to use `FetchContent` to directly get content from a specific commit on the OSQP repository, which streamlines the process.  